### PR TITLE
Deploy Storybook Static to Now.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ whitelist: &whitelist
     - src/*
     - stories/*
     - node_modules/*
+    - storybook-static/*
 
 version: 2
 jobs:
@@ -66,8 +67,22 @@ jobs:
           name: Write NPM Token to ~/.npmrc
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run:
-          name: Write version to package.json
+          name: Deploy to NPM
           command: npm publish --access=public
+  storybook:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Build static Storybook Site
+          command: yarn run build-storybook
+      - run:
+          name: Setup Now
+          command: yarn global add now
+      - run:
+          name: Deploy and Alias
+          command: cd storybook-static && now -t ${NOW_TOKEN} . && now -t ${NOW_TOKEN} alias
 
 workflows:
   version: 2
@@ -80,6 +95,22 @@ workflows:
           filters:
             tags:
               only: /.*/
+  storybook:
+    jobs:
+      - checkout:
+          filters:
+            tags:
+              only: /storybook-[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/
+      - storybook:
+          requires:
+            - checkout
+          filters:
+            tags:
+              only: /storybook-[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/
   deploy:
     jobs:
       - checkout:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 build/index.js
 .idea
 *.swp
+/storybook-static/static
+/storybook-static/favicon.ico
+/storybook-static/iframe.html
+/storybook-static/index.html

--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,5 @@
 .storybook
 .circleci
 webpack.config.js
+now.json
+/storybook-static

--- a/.npmignore
+++ b/.npmignore
@@ -7,5 +7,4 @@
 .storybook
 .circleci
 webpack.config.js
-now.json
 /storybook-static

--- a/storybook-static/now.json
+++ b/storybook-static/now.json
@@ -1,0 +1,3 @@
+{
+  "alias": "jsdrupal-component-docs"
+}


### PR DESCRIPTION
- Deploy to now automatically from CircleCI
- Executes workflow `storybook` only on a matching tag, `storybook-`
- Automatically aliases release to `https://jsdrupal-components-docs.now.sh`
  - This is configured in the `now.json` file.