### PR TITLE
Polyfills

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.34",
-    "@babel/polyfill": "^7.0.0-beta.38",
     "@babel/preset-env": "^7.0.0-beta.34",
     "@babel/preset-react": "^7.0.0-beta.34",
     "@storybook/addon-actions": "^3.3.8",
@@ -39,6 +38,7 @@
     "webpack": "^3.10.0"
   },
   "dependencies": {
+    "@babel/polyfill": "^7.0.0-beta.38",
     "classnames": "^2.2.5",
     "prop-types": "^15.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "build": "NODE_ENV=production ./node_modules/.bin/webpack --progress --display-modules --config webpack.config.js",
     "watch": "./node_modules/.bin/webpack --progress --watch --config webpack.config.js",
     "lint": "./node_modules/.bin/eslint -c .eslintrc.json .",
-    "prettier": "./node_modules/.bin/prettier --write \"{src,stories}/**/*.js\"",
+    "prettier": "./node_modules/.bin/prettier --write '{src,stories}/**/*.js' 'webpack.config.js'",
     "storybook": "./node_modules/.bin/start-storybook -p 1337 -c .storybook",
     "build-storybook": "./node_modules/.bin/build-storybook"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.34",
+    "@babel/polyfill": "^7.0.0-beta.38",
     "@babel/preset-env": "^7.0.0-beta.34",
     "@babel/preset-react": "^7.0.0-beta.34",
     "@storybook/addon-actions": "^3.3.8",
@@ -21,6 +22,7 @@
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.3",
     "babel-loader": "8.0.0-beta.0",
+    "babel-minify-webpack-plugin": "^0.2.0",
     "babel-plugin-emotion": "^8.0.12",
     "babel-plugin-transform-class-properties": "7.0.0-beta.3",
     "babel-plugin-transform-object-rest-spread": "7.0.0-beta.3",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import '@babel/polyfill';
+
 import { Breadcrumb, BreadcrumbItem } from './components/breadcrumb';
 import Button from './components/button';
 import Card from './components/card';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const webpack = require('webpack');
+const Minify = require('babel-minify-webpack-plugin');
 
 const productionPluginDefine =
   process.env.NODE_ENV === 'production'
@@ -7,7 +8,7 @@ const productionPluginDefine =
         new webpack.DefinePlugin({
           'process.env.NODE_ENV': JSON.stringify('production'),
         }),
-        new webpack.optimize.UglifyJsPlugin(),
+        new Minify(),
       ]
     : [];
 
@@ -46,8 +47,15 @@ module.exports = [
                 '@babel/preset-env',
                 {
                   modules: false,
+                  useBuiltIns: 'entry',
                   targets: {
-                    browsers: ['last 2 versions'],
+                    browsers: [
+                      'Chrome >= 62',
+                      'Edge >= 15',
+                      'FireFox >= 56',
+                      'Safari >= 11',
+                      'Opera >= 47',
+                    ],
                   },
                 },
               ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,11 +50,11 @@ module.exports = [
                   useBuiltIns: 'entry',
                   targets: {
                     browsers: [
-                      'Chrome >= 62',
-                      'Edge >= 15',
-                      'FireFox >= 56',
-                      'Safari >= 11',
-                      'Opera >= 47',
+                      'chrome >= 62',
+                      'edge >= 15',
+                      'fireFox >= 56',
+                      'safari >= 11',
+                      'opera >= 47',
                     ],
                   },
                 },

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,6 +416,13 @@
     "@babel/helper-regex" "7.0.0-beta.35"
     regexpu-core "^4.1.3"
 
+"@babel/polyfill@^7.0.0-beta.38":
+  version "7.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.0.0-beta.38.tgz#df9ca32ffe4f6de0b99ab495c197837f422bb12e"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.1"
+
 "@babel/preset-env@^7.0.0-beta.34":
   version "7.0.0-beta.35"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.0.0-beta.35.tgz#634431813b14ebe841f293fbf459a3ffa61d7ef6"
@@ -1032,7 +1039,7 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.26.0:
+babel-core@^6.24.1, babel-core@^6.26.0:
   version "6.26.0"
   resolved "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz#af32f78b31a6fcef119c87b0fd8d9753f03a0bb8"
   dependencies:
@@ -1274,6 +1281,14 @@ babel-messages@^6.23.0:
   resolved "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
   dependencies:
     babel-runtime "^6.22.0"
+
+babel-minify-webpack-plugin@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/babel-minify-webpack-plugin/-/babel-minify-webpack-plugin-0.2.0.tgz#ef9694d11a1b8ab8f3204d89f5c9278dd28fc2a9"
+  dependencies:
+    babel-core "^6.24.1"
+    babel-preset-minify "^0.2.0"
+    webpack-sources "^1.0.1"
 
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
@@ -1851,7 +1866,7 @@ babel-preset-flow@^6.23.0:
 
 babel-preset-minify@^0.2.0:
   version "0.2.0"
-  resolved "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.2.0.tgz#006566552d9b83834472273f306c0131062a0acc"
+  resolved "https://registry.yarnpkg.com/babel-preset-minify/-/babel-preset-minify-0.2.0.tgz#006566552d9b83834472273f306c0131062a0acc"
   dependencies:
     babel-plugin-minify-builtins "^0.2.0"
     babel-plugin-minify-constant-folding "^0.2.0"
@@ -5866,7 +5881,7 @@ regenerate@^1.2.1, regenerate@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
 
-regenerator-runtime@^0.11.0:
+regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 


### PR DESCRIPTION
Here's a thing,

- Use `@babel/polyfill`
- [Configure](https://github.com/babel/babel/tree/master/packages/babel-preset-env#usebuiltins-entry) `babel-preset-env` with `useBuiltIns: 'entry'`

This has the side effect that our bundle size has increased somewhat dramatically. Prior to polyfills being included, the bundle was at `21.5 kB` however with polyfills included it's at `39.6 kB`.

![](https://media.giphy.com/media/3oFzmjlJNaddxgL23m/giphy.gif)